### PR TITLE
brpc-build: add path finder for `protoc-gen-brpc`

### DIFF
--- a/examples/build.rs
+++ b/examples/build.rs
@@ -11,9 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-fn main() {
-    match brpc_build::compile_protos(&["echo/echo.proto"], &["echo"]) {
-        Ok(_) => (),
-        Err(e) => println!("{:?}", e),
-    }
+fn main() -> std::io::Result<()> {
+    brpc_build::compile_protos(&["echo/echo.proto"], &["echo"])
 }


### PR DESCRIPTION
We need check that if `protoc-gen-brpc` could be found in $PATH first in `brpc-build` module, and prevent the whole compilation early. Otherwise, the final error message will puzzle our users.

before :

```bash
   Compiling examples v0.1.0-alpha (/home/wayslog/rust/brpc-rs/examples)
error: couldn't read /home/wayslog/rust/brpc-rs/target/debug/build/examples-33f7d7c2d60a1487/out/example.brpc.rs: No such file or directory (os error 2)
  --> examples/echo/server.rs:18:5
   |
18 |     include!(concat!(env!("OUT_DIR"), "/example.brpc.rs"));
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: aborting due to previous error

error: Could not compile `examples`.
```

after:
```
   Compiling examples v0.1.0-alpha (/home/wayslog/rust/brpc-rs/examples)
error: failed to run custom build command for `examples v0.1.0-alpha (/home/wayslog/rust/brpc-rs/examples)`

Caused by:
  process didn't exit successfully: `/home/wayslog/rust/brpc-rs/target/debug/build/examples-685063835f1f4bb0/build-script-build` (exit code: 1)
--- stderr
Error: Custom { kind: NotFound, error: "protoc-gen-brpc not found in PATH" }
```